### PR TITLE
Ignore synthetic methods in Reflection

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
@@ -26,7 +26,7 @@ class Reflection {
     static <D extends DynamicObject<D>> Collection<Method> fieldGetters(Class<D> type) {
         Collection<Method> ret = new LinkedHashSet<>();
         for (Method method : type.getDeclaredMethods())
-            if (method.getParameterCount() == 0 && !method.isDefault() && !isMetadataGetter(method))
+            if (method.getParameterCount() == 0 && !method.isDefault() && !method.isSynthetic() && !isMetadataGetter(method))
                 ret.add(method);
         return ret;
     }


### PR DESCRIPTION
Synthetic methods are ones added by the compiler, or other systems like a code coverage package.  These added methods will (by definition) not have any dynamic object related tags like Key or Meta associated with them, so we should ignore them.
